### PR TITLE
add redundant assignment that triggers Warning-LATCH in Verilator

### DIFF
--- a/src/gpio.sv
+++ b/src/gpio.sv
@@ -186,6 +186,8 @@ module gpio #(
 
     // GPIO set, clear and toggle logic
     always_comb begin
+      s_hw2reg.gpio_out[gpio_idx].d = s_reg2hw.gpio_out[gpio_idx].q;
+      s_hw2reg.gpio_out[gpio_idx].de = 1'b0;
       unique if (s_reg2hw.gpio_set[gpio_idx].qe && s_reg2hw.gpio_set[gpio_idx].q) begin
         `assert_condition(s_reg2hw.gpio_set[gpio_idx].qe && s_reg2hw.gpio_set[gpio_idx].q, rst_ni);
         s_hw2reg.gpio_out[gpio_idx].d = 1'b1;


### PR DESCRIPTION
I know it is not a LATCH, but Verilator complains...
`%Warning-LATCH: ../../../hw/vendor/pulp_platform_gpio/src/gpio.sv:188:5: Latch inferred for signal 's_hw2reg' (not all control paths of combinational always assign a value)
                                                                       : ... Suggest use of always_latch for intentional latches
  188 |     always_comb begin
      |     ^~~~~~~~~~~
`
