### PR TITLE
Remove sampling mode condition to allow for loopback testing

### DIFF
--- a/src/gpio.sv
+++ b/src/gpio.sv
@@ -144,7 +144,7 @@ module gpio #(
       ) i_sync_gpio_input(
         .clk_i,
         .rst_ni,
-        .en_i(s_reg2hw.gpio_en[gpio_idx].q && s_reg2hw.gpio_mode[gpio_idx].q == 0),
+        .en_i(s_reg2hw.gpio_en[gpio_idx].q),
         .serial_i(gpio_in[gpio_idx]),
         .r_edge_o(s_gpio_rise_edge[gpio_idx]),
         .f_edge_o(s_gpio_fall_edge[gpio_idx]),


### PR DESCRIPTION
While using this block, I attempted to run a loopback test using firmware that is connected to a PULP GPIO block via the Control Status Registers (CSR)s. Our GPIO is wired up to a pad as the diagram shows below:

![pulp_gpio_example drawio](https://github.com/pulp-platform/gpio/assets/94083344/d664883a-bd24-4f64-afdc-17843525e077)

My expectation is that when both `Input Enable` and `Output Enable` are high (controlled through other CSRs), that whatever value I set `GPIO Output` to should be synchronized on `GPIO Input`. Imagine my surprise when this was not the case! Since the input synchronizer enable is tied to the GPIO mode being set to `Input`, this prevents all loopback testing. This is a very handy feature that should not be disabled.

While an argument could be made this protects against shorts, if I as a firmware engineer want to create a short I could do so through the CSRs one way or another. By removing the ability to perform loopback testing, I will never know if I had shorted a GPIO line!

I hope this makes sense, please let me know if you have any questions.