### PR TITLE
Explicitly import needed SV packages

### DIFF
--- a/src/gpio_apb_wrap.sv
+++ b/src/gpio_apb_wrap.sv
@@ -81,7 +81,9 @@ module gpio_apb_wrap # (
 endmodule // gpio_apb_wrap
 
 
-module gpio_apb_wrap_intf # (
+module gpio_apb_wrap_intf
+  import apb_pkg::*;
+# (
   /// ADDR_WIDTH of the APB interface
   parameter int unsigned  ADDR_WIDTH = 32,
   /// DATA_WIDTH of the APB interface

--- a/src/gpio_axi_lite_wrap.sv
+++ b/src/gpio_axi_lite_wrap.sv
@@ -104,7 +104,9 @@ module gpio_axi_lite_wrap # (
 
 endmodule
 
-module gpio_axi_lite_wrap_intf # (
+module gpio_axi_lite_wrap_intf
+  import axi_pkg::*;
+# (
   /// ADDR_WIDTH of the AXI lite interface
   parameter int unsigned  ADDR_WIDTH = 32,
   /// DATA_WIDTH of the AXI lite interface


### PR DESCRIPTION
The previous code assumed axi_pkg/apb_pkg was available in the global namespace which is not necessarily true depending on how the compilations is done.